### PR TITLE
Alternative way of hooking to Toolbar

### DIFF
--- a/Assets/ToolbarExtender/Example/Scripts/Editor/SceneViewFocuser.cs
+++ b/Assets/ToolbarExtender/Example/Scripts/Editor/SceneViewFocuser.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class SceneViewFocuser
+{
+    static bool m_enabled;
+
+    public static bool Enabled
+    {
+        get { return m_enabled; }
+        set
+        {
+            m_enabled = value;
+            EditorPrefs.SetBool("SceneViewFocuser", value);
+        }
+    }
+
+    static SceneViewFocuser()
+    {
+        m_enabled = EditorPrefs.GetBool("SceneViewFocuser", false);
+        EditorApplication.playModeStateChanged += OnPlayModeChanged;
+        EditorApplication.pauseStateChanged += OnPauseChanged;
+
+        ToolbarExtension.RightToolbar.Add(OnToolbar);
+    }
+
+    private static void OnPauseChanged(PauseState obj)
+    {
+        if (Enabled && obj == PauseState.Unpaused)
+        {
+            // Not sure why, but this must be delayed
+            EditorApplication.delayCall += () => EditorWindow.FocusWindowIfItsOpen<SceneView>();
+        }
+    }
+
+    private static void OnPlayModeChanged(PlayModeStateChange obj)
+    {
+        if (Enabled && obj == PlayModeStateChange.EnteredPlayMode)
+        {
+            EditorWindow.FocusWindowIfItsOpen<SceneView>();
+        }
+    }
+
+    private static void OnToolbar()
+    {
+        var tex = (Texture)EditorGUIUtility.Load(@"UnityEditor.SceneView");
+
+        GUI.changed = false;
+        GUILayout.Toggle(m_enabled, new GUIContent(null, tex, "Focus SceneView when entering play mode"), "Command");
+        if (GUI.changed)
+        {
+            Enabled = !Enabled;
+        }
+    }
+}

--- a/Assets/ToolbarExtender/Example/Scripts/Editor/SceneViewFocuser.cs.meta
+++ b/Assets/ToolbarExtender/Example/Scripts/Editor/SceneViewFocuser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8ddf5f9fafe5734dbae1d30d51bb2a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarCallback.cs
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarCallback.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using UnityEditor;
+using System.Reflection;
+using UnityEngine.Experimental.UIElements;
+
+public static class ToolbarCallback
+{
+    static Type m_toolbarType = typeof(Editor).Assembly.GetType("UnityEditor.Toolbar");
+    static Type m_guiViewType = typeof(Editor).Assembly.GetType("UnityEditor.GUIView");
+    static PropertyInfo m_viewVisualTree = m_guiViewType.GetProperty("visualTree", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    static FieldInfo m_imguiContainerOnGui = typeof(IMGUIContainer).GetField("m_OnGUIHandler", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+    static ScriptableObject m_currentToolbar;
+
+    /// <summary>
+    /// Callback for toolbar OnGUI method.
+    /// </summary>
+    public static Action OnToolbarGUI;
+
+    static ToolbarCallback()
+    {
+        EditorApplication.update -= OnUpdate;
+        EditorApplication.update += OnUpdate;
+    }
+
+    static void OnUpdate()
+    {
+        // Relying on the fact that toolbar is ScriptableObject and gets deleted when layout changes
+        if (m_currentToolbar == null)
+        {
+            // Find toolbar
+            var toolbars = Resources.FindObjectsOfTypeAll(m_toolbarType);
+            m_currentToolbar = toolbars.Length > 0 ? (ScriptableObject)toolbars[0] : null;
+            if (m_currentToolbar != null)
+            {
+                // Get it's visual tree
+                var visualTree = (VisualElement)m_viewVisualTree.GetValue(m_currentToolbar, null);
+
+                // Get first child which 'happens' to be toolbar IMGUIContainer
+                var container = (IMGUIContainer)visualTree[0];
+
+                // (Re)attach handler
+                var handler = (Action)m_imguiContainerOnGui.GetValue(container);
+                handler -= OnGUI;
+                handler += OnGUI;
+                m_imguiContainerOnGui.SetValue(container, handler);
+            }
+        }
+    }
+
+    static void OnGUI()
+    {
+        var handler = OnToolbarGUI;
+        if (handler != null) handler();
+    }
+}

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarCallback.cs.meta
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6249d6d81278a6a42a2fb1acc3781543
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtension.cs
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtension.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class ToolbarExtension
+{
+    static int m_toolCount;
+    static GUIStyle m_commandStyle = null;
+
+    public static readonly List<Action> LeftToolbar = new List<Action>();
+    public static readonly List<Action> RightToolbar = new List<Action>();
+
+    static ToolbarExtension()
+    {
+        Type toolbarType = typeof(Editor).Assembly.GetType("UnityEditor.Toolbar");
+        FieldInfo toolIcons = toolbarType.GetField("s_ShownToolIcons", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        m_toolCount = toolIcons != null ? ((Array)toolIcons.GetValue(null)).Length : 6;
+
+        ToolbarCallback.OnToolbarGUI -= OnGUI;
+        ToolbarCallback.OnToolbarGUI += OnGUI;
+    }
+
+    private static void OnGUI()
+    {
+        // Create two containers, left and right
+        // Screen is whole toolbar
+
+        if (m_commandStyle == null)
+        {
+            m_commandStyle = new GUIStyle("CommandLeft");
+        }
+
+        // Following calculations match code reflected from Toolbar.OldOnGUI()
+        float playButtonsPosition = (Screen.width - 100) / 2;
+
+        Rect leftRect = new Rect(0, 0, Screen.width, Screen.height);
+        leftRect.xMin += 10; // Spacing left
+        leftRect.xMin += 32 * m_toolCount; // Tool buttons
+        leftRect.xMin += 20; // Spacing between tools and pivot
+        leftRect.xMin += 64 * 2; // Pivot buttons
+        leftRect.xMax = playButtonsPosition;
+
+        Rect rightRect = new Rect(0, 0, Screen.width, Screen.height);
+        rightRect.xMin = playButtonsPosition;
+        rightRect.xMin += m_commandStyle.fixedWidth * 3; // Play buttons
+        rightRect.xMax = Screen.width;
+        rightRect.xMax -= 10; // Spacing right
+        rightRect.xMax -= 80; // Layout
+        rightRect.xMax -= 10; // Spacing between layout and layers
+        rightRect.xMax -= 80; // Layers
+        rightRect.xMax -= 20; // Spacing between layers and account
+        rightRect.xMax -= 80; // Account
+        rightRect.xMax -= 10; // Spacing between account and cloud
+        rightRect.xMax -= 32; // Cloud
+        rightRect.xMax -= 10; // Spacing between cloud and collab
+        rightRect.xMax -= 78; // Colab
+
+        // Add spacing around existing controls
+        leftRect.xMin += 10;
+        leftRect.xMax -= 10;
+        rightRect.xMin += 10;
+        rightRect.xMax -= 10;
+
+        // Add top and bottom margins
+        leftRect.y = 5;
+        leftRect.height = 24;
+        rightRect.y = 5;
+        rightRect.height = 24;
+
+        if (leftRect.width > 0)
+        {
+            GUILayout.BeginArea(leftRect);
+            GUILayout.BeginHorizontal();
+            foreach (var handler in LeftToolbar)
+            {
+                handler();
+            }
+            GUILayout.EndHorizontal();
+            GUILayout.EndArea();
+            //EditorGUI.DrawRect(leftRect, Color.white); // Visual validation
+        }
+        if (rightRect.width > 0)
+        {
+            GUILayout.BeginArea(rightRect);
+            GUILayout.BeginHorizontal();
+            foreach (var handler in RightToolbar)
+            {
+                handler();
+            }
+            GUILayout.EndHorizontal();
+            GUILayout.EndArea();
+            //EditorGUI.DrawRect(rightRect, Color.white); // Visual validation
+        }
+    }
+}

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtension.cs.meta
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98dc2ee9817d16c4e8c71d552b4c7c76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Simple way of hooking toolbar. Helper class for easy layout on toolbar and example of useful tool on toolbar. Fixes #5 

Since this uses different approach, original code is left untouched.

`ToolbarCallback` responsible for hooking to toolbar and providing simple callback
`ToolbarExtension` helper class which provides two callbacks for drawing on left and right side of toolbar
- left area is dynamic, between pivot and play buttons
- right area is dynamic, between play buttons and collab button
- user is expected to use GUILayout for drawing

`SceneViewFocuser` use example of extending toolbar
- useful tool which keeps focus on scene when entering play mode or when unpausing

![toolbarext](https://user-images.githubusercontent.com/3371096/48252439-0f738b00-e405-11e8-838d-95992e1d7808.png)
