### PR TITLE
Update ToolbarExtender.cs

### DIFF
--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
@@ -9,19 +9,6 @@ namespace UnityToolbarExtender
 	[InitializeOnLoad]
 	public static class ToolbarExtender
 	{
-		public static class StandardDimensions
-		{
-			public const float space = 10;
-			public const float largeSpace = 20;
-			public const float buttonWidth = 32;
-			public const float dropdownWidth = 80;
-#if UNITY_2019_1_OR_NEWER
-			public const float playPauseStopWidth = 140;
-#else
-			public const float playPauseStopWidth = 100;
-#endif
-		}
-		
 		static int m_toolCount;
 		static GUIStyle m_commandStyle = null;
 
@@ -55,11 +42,15 @@ namespace UnityToolbarExtender
 
 		static void OnGUI()
 		{
-			const float space = StandardDimensions.space;
-			const float largeSpace = StandardDimensions.largeSpace;
-			const float buttonWidth = StandardDimensions.buttonWidth;
-			const float dropdownWidth = StandardDimensions.dropdownWidth;
-			const float playPauseStopWidth = StandardDimensions.playPauseStopWidth;
+			public const float space = 10;
+			public const float largeSpace = 20;
+			public const float buttonWidth = 32;
+			public const float dropdownWidth = 80;
+#if UNITY_2019_1_OR_NEWER
+			public const float playPauseStopWidth = 140;
+#else
+			public const float playPauseStopWidth = 100;
+#endif
 			
 			// Create two containers, left and right
 			// Screen is whole toolbar

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
@@ -63,7 +63,6 @@ namespace UnityToolbarExtender
 			var screenWidth = EditorGUIUtility.currentViewWidth;
 
 			// Following calculations match code reflected from Toolbar.OldOnGUI()
-			float playButtonsPosition = (screenWidth - 100) / 2;
 			float playButtonsPosition = Mathf.RoundToInt ((screenWidth - playPauseStopWidth) / 2);
 
 			Rect leftRect = new Rect(0, 0, screenWidth, Screen.height);

--- a/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
+++ b/Assets/ToolbarExtender/Scripts/Editor/ToolbarExtender.cs
@@ -9,6 +9,19 @@ namespace UnityToolbarExtender
 	[InitializeOnLoad]
 	public static class ToolbarExtender
 	{
+		public static class StandardDimensions
+		{
+			public const float space = 10;
+			public const float largeSpace = 20;
+			public const float buttonWidth = 32;
+			public const float dropdownWidth = 80;
+#if UNITY_2019_1_OR_NEWER
+			public const float playPauseStopWidth = 140;
+#else
+			public const float playPauseStopWidth = 100;
+#endif
+		}
+		
 		static int m_toolCount;
 		static GUIStyle m_commandStyle = null;
 
@@ -42,6 +55,12 @@ namespace UnityToolbarExtender
 
 		static void OnGUI()
 		{
+			const float space = StandardDimensions.space;
+			const float largeSpace = StandardDimensions.largeSpace;
+			const float buttonWidth = StandardDimensions.buttonWidth;
+			const float dropdownWidth = StandardDimensions.dropdownWidth;
+			const float playPauseStopWidth = StandardDimensions.playPauseStopWidth;
+			
 			// Create two containers, left and right
 			// Screen is whole toolbar
 
@@ -54,11 +73,12 @@ namespace UnityToolbarExtender
 
 			// Following calculations match code reflected from Toolbar.OldOnGUI()
 			float playButtonsPosition = (screenWidth - 100) / 2;
+			float playButtonsPosition = Mathf.RoundToInt ((screenWidth - playPauseStopWidth) / 2);
 
 			Rect leftRect = new Rect(0, 0, screenWidth, Screen.height);
-			leftRect.xMin += 10; // Spacing left
-			leftRect.xMin += 32 * m_toolCount; // Tool buttons
-			leftRect.xMin += 20; // Spacing between tools and pivot
+			leftRect.xMin += space; // Spacing left
+			leftRect.xMin += buttonWidth * m_toolCount; // Tool buttons
+			leftRect.xMin += largeSpace; // Spacing between tools and pivot
 			leftRect.xMin += 64 * 2; // Pivot buttons
 			leftRect.xMax = playButtonsPosition;
 
@@ -66,22 +86,22 @@ namespace UnityToolbarExtender
 			rightRect.xMin = playButtonsPosition;
 			rightRect.xMin += m_commandStyle.fixedWidth * 3; // Play buttons
 			rightRect.xMax = screenWidth;
-			rightRect.xMax -= 10; // Spacing right
-			rightRect.xMax -= 80; // Layout
-			rightRect.xMax -= 10; // Spacing between layout and layers
-			rightRect.xMax -= 80; // Layers
-			rightRect.xMax -= 20; // Spacing between layers and account
-			rightRect.xMax -= 80; // Account
-			rightRect.xMax -= 10; // Spacing between account and cloud
-			rightRect.xMax -= 32; // Cloud
-			rightRect.xMax -= 10; // Spacing between cloud and collab
+			rightRect.xMax -= space; // Spacing right
+			rightRect.xMax -= dropdownWidth; // Layout
+			rightRect.xMax -= space; // Spacing between layout and layers
+			rightRect.xMax -= dropdownWidth; // Layers
+			rightRect.xMax -= largeSpace; // Spacing between layers and account
+			rightRect.xMax -= dropdownWidth; // Account
+			rightRect.xMax -= space; // Spacing between account and cloud
+			rightRect.xMax -= buttonWidth; // Cloud
+			rightRect.xMax -= space; // Spacing between cloud and collab
 			rightRect.xMax -= 78; // Colab
 
 			// Add spacing around existing controls
-			leftRect.xMin += 10;
-			leftRect.xMax -= 10;
-			rightRect.xMin += 10;
-			rightRect.xMax -= 10;
+			leftRect.xMin += space;
+			leftRect.xMax -= space;
+			rightRect.xMin += space;
+			rightRect.xMax -= space;
 
 			// Add top and bottom margins
 			leftRect.y = 5;


### PR DESCRIPTION
in 2019 the center buttons are 140 of width instead of 100, as it was in 2018.
While fixing that, I thought that the "StandardDimensions" would have been a nice feature, but if you think it's better without it, I can remove it from my edit before you accept the pull request! :)