### PR TITLE
Fix disappearing custom toolbars

### DIFF
--- a/Editor/ToolbarCallback.cs
+++ b/Editor/ToolbarCallback.cs
@@ -77,6 +77,9 @@ namespace UnityToolbarExtender
 						parent.Add(container);
 						toolbarZone.Add(parent);
 					}
+
+					// Handle root visual element being detached from m_currentToolbar when changing between displays of different DPI
+					mRoot.RegisterCallback<DetachFromPanelEvent>(_ => m_currentToolbar = null);
 #else
 #if UNITY_2020_1_OR_NEWER
 					var windowBackend = m_windowBackend.GetValue(m_currentToolbar);


### PR DESCRIPTION
It would appear that when dragging Unity between monitors with different DPI settings (as described in https://github.com/marijnz/unity-toolbar-extender/issues/34) that the root visual element is detached, but m_currentToolbar does not become null.

To address this issue I registered for the DetachFromPanelEvent and clear the m_currentToolbar variable to trigger the setup process again.